### PR TITLE
Add unit-test to check that 1 wei is discarded when depositing 1 wei SMR

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "npx hardhat test",
     "code-coverage": "npx hardhat coverage",
     "test-late-quorum": "npx hardhat test ./test/proposal-transfer-native-smr-late-quorum.ts",
+    "test-wsmr": "npx hardhat test ./test/wsmr-deposit.ts --network shimmerEvmTestnet",
     "deploy-hardhat": "npx hardhat run scripts/deploy_governance.ts --network hardhat",
     "deploy-shimmerEvmTestnet": "npx hardhat run scripts/deploy_governance.ts --network shimmerEvmTestnet",
     "deploy-shimmerEvmMainnet": "npx hardhat run scripts/deploy_governance.ts --network shimmerEvmMainnet",

--- a/test/wsmr-deposit.ts
+++ b/test/wsmr-deposit.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { wSMR } from "../typechain-types";
+import deployIFVotesToken from "../deploy/wSMR-token";
+import { getBalanceNative } from "../utils";
+
+describe("Deposit 1 wei to get wSMR token", () => {
+  let wSMRTokenContract: wSMR;
+  let signer: any;
+
+  it("Reference wSMR token contract", async () => {
+    [signer] = await ethers.getSigners();
+    wSMRTokenContract = await deployIFVotesToken();
+  });
+
+  it("Deposit 1 wei and check SMR balance before/after to see that 1 wei is discarded.", async () => {
+    const ONE_WEI = BigInt(1);
+    const userWalletAddress = await signer.getAddress();
+    console.log("userWalletAddress:", userWalletAddress);
+
+    const userBalanceBeforeDeposit = await getBalanceNative(userWalletAddress);
+    // console.log("userBalanceBeforeDeposit:", userBalanceBeforeDeposit);
+
+    // Depost 1 wei
+    await wSMRTokenContract.connect(signer).deposit({
+      value: ONE_WEI,
+    });
+
+    const userBalanceAfterDeposit = await getBalanceNative(userWalletAddress);
+    // console.log("userBalanceAfterDeposit:", userBalanceAfterDeposit);
+
+    // const userBalanceWSMRTokens = await wSMRTokenContract.balanceOf(
+    //   userWalletAddress
+    // );
+    // console.log(
+    //   "userBalanceWSMRTokens:",
+    //   userBalanceWSMRTokens / BigInt(Math.pow(10, 18))
+    // );
+
+    const txFee = BigInt(60_058 * (1000 * Math.pow(10, 9)));
+
+    // Always failed because 1 wei is discarded
+    expect(userBalanceAfterDeposit + ONE_WEI + txFee).to.equal(
+      userBalanceBeforeDeposit
+    );
+  });
+});


### PR DESCRIPTION
This added unit-test is to check that 1 wei is really discarded because it is not deducted from user wallet balance upon depositing 1 wei SMR via the erc20 token contract `wSMR`. Root cause is because native gas token SMR uses 6 decimals while wSMR tokens use 18 decimals. With 6 decimals, any SMR value lower than 0.000001 will be treated zero. 